### PR TITLE
Check initramFS update by MD5

### DIFF
--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -96,6 +96,7 @@ class DeviceUpdater(PHALPlugin):
         if new_hash == old_hash:
             LOG.debug("initramfs not changed")
             return False
+        LOG.info("initramfs update available")
         return True
 
     def _get_initramfs_latest(self) -> bool:
@@ -140,6 +141,7 @@ class DeviceUpdater(PHALPlugin):
         if installed_image_time and installed_image_time in newest_version:
             LOG.info("Already updated")
             return None
+        LOG.info(f"New squashFS: {newest_version}")
         return newest_version, download_url
 
     def _get_squashfs_latest(self) -> Optional[str]:

--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -80,6 +80,24 @@ class DeviceUpdater(PHALPlugin):
                 self._build_info = dict()
         return self._build_info
 
+    def _check_initramfs_update_available(self):
+        """
+        Check if there is a newer initramfs version available by comparing MD5
+        """
+        if not self.initramfs_url:
+            raise RuntimeError("No initramfs_url configured")
+        md5_request = requests.get(f"{self.initramfs_url}.md5")
+        if not md5_request.ok:
+            LOG.warning("Unable to get md5; downloading latest initramfs")
+            return self._get_initramfs_latest()
+        new_hash = md5_request.text.split('\n')[0]
+        with open(self.initramfs_real_path, 'rb') as f:
+            old_hash = hashlib.md5(f.read()).hexdigest()
+        if new_hash == old_hash:
+            LOG.debug("initramfs not changed")
+            return False
+        return True
+
     def _get_initramfs_latest(self) -> bool:
         """
         Get the latest initramfs image and check if it is different from the
@@ -99,7 +117,7 @@ class DeviceUpdater(PHALPlugin):
             new_hash = hashlib.md5(initramfs_request.content).hexdigest()
             with open(self.initramfs_update_path, 'wb+') as f:
                 f.write(initramfs_request.content)
-        with open("/boot/firmware/initramfs", 'rb') as f:
+        with open(self.initramfs_real_path, 'rb') as f:
             old_hash = hashlib.md5(f.read()).hexdigest()
         if new_hash == old_hash:
             LOG.debug("initramfs not changed")
@@ -165,7 +183,7 @@ class DeviceUpdater(PHALPlugin):
         Handle a request to check for initramfs updates
         @param message: `neon.check_update_initramfs` Message
         """
-        update_available = self._get_initramfs_latest()
+        update_available = self._check_initramfs_update_available()
         self.bus.emit(message.response({"update_available": update_available}))
 
     def check_update_squashfs(self, message: Message):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -27,10 +27,10 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+import requests
 
-from os.path import isfile, basename
-from unittest.mock import Mock
-from ovos_bus_client.message import Message
+from os import remove
+from os.path import isfile, basename, join, dirname
 from neon_phal_plugin_device_updater import DeviceUpdater
 from ovos_utils.messagebus import FakeBus
 
@@ -41,6 +41,19 @@ class PluginTests(unittest.TestCase):
 
     def test_build_info(self):
         self.assertIsInstance(self.plugin.build_info, dict)
+
+    def test_check_initramfs_update_available(self):
+        self.plugin.initramfs_real_path = join(dirname(__file__), "initramfs")
+        with open(self.plugin.initramfs_real_path, 'w+') as f:
+            f.write("test")
+        self.assertTrue(self.plugin._check_initramfs_update_available())
+
+        # Explicitly get valid initramfs
+        with open(self.plugin.initramfs_real_path, 'wb') as f:
+            f.write(requests.get(self.plugin.initramfs_url).content)
+        self.assertFalse(self.plugin._check_initramfs_update_available())
+
+        remove(self.plugin.initramfs_real_path)
 
     def test_get_initramfs_latest(self):
         # TODO


### PR DESCRIPTION
# Description
Use MD5 sum to check initramfs updates instead of downloading new version to check

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->