### PR TITLE
Update InitramFS Hash Checks

### DIFF
--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -80,6 +80,9 @@ class DeviceUpdater(PHALPlugin):
                     self._initramfs_hash = hashlib.md5(f.read()).hexdigest()
             except Exception as e:
                 LOG.error(e)
+                if isfile(self.initramfs_real_path):
+                    with open(self.initramfs_real_path, "rb") as f:
+                        self._initramfs_hash = hashlib.md5(f.read()).hexdigest()
         return self._initramfs_hash
 
     @property

--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -52,7 +52,7 @@ class DeviceUpdater(PHALPlugin):
                                              "neon_debos/raw/dev/overlays/"
                                              "02-rpi4/boot/firmware/initramfs")
         self.initramfs_real_path = self.config.get("initramfs_path",
-                                                   "/opt/neon/initramfs")
+                                                   "/opt/neon/firmware/initramfs")
         self.initramfs_update_path = self.config.get("initramfs_upadate_path",
                                                      "/opt/neon/initramfs")
         self.squashfs_url = self.config.get("squashfs_url",
@@ -266,14 +266,14 @@ class DeviceUpdater(PHALPlugin):
         @param message: `neon.update_initramfs` Message
         """
         try:
-            LOG.info("Checking initramfs update")
+            LOG.info("Performing initramfs update")
             if not isfile(self.initramfs_real_path) and \
                     not message.data.get("force_update"):
                 LOG.debug("No initramfs to update")
                 response = message.response({"updated": None,
                                              "error": "No initramfs to update"})
             elif not self._get_initramfs_latest():
-                LOG.debug("No initramfs update")
+                LOG.info("No initramfs update")
                 response = message.response({"updated": False})
             else:
                 LOG.debug("Updating initramfs")

--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -72,7 +72,7 @@ class DeviceUpdater(PHALPlugin):
         self.bus.on("neon.update_squashfs", self.update_squashfs)
 
     @property
-    def initramfs_md5(self) -> Optional[str]:
+    def initramfs_hash(self) -> Optional[str]:
         if not self._initramfs_hash:
             try:
                 Popen("mount_firmware", shell=True).wait(5)
@@ -106,7 +106,7 @@ class DeviceUpdater(PHALPlugin):
             return self._get_initramfs_latest()
         new_hash = md5_request.text.split('\n')[0]
 
-        if new_hash == self._initramfs_hash:
+        if new_hash == self.initramfs_hash:
             LOG.info("initramfs not changed")
             return False
         LOG.info("initramfs update available")
@@ -133,7 +133,7 @@ class DeviceUpdater(PHALPlugin):
             with open(self.initramfs_update_path, 'wb+') as f:
                 f.write(initramfs_request.content)
 
-        if new_hash == self._initramfs_hash:
+        if new_hash == self.initramfs_hash:
             LOG.info("initramfs not changed. Removing downloaded file.")
             remove(self.initramfs_update_path)
             return False

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -46,11 +46,13 @@ class PluginTests(unittest.TestCase):
         self.plugin.initramfs_real_path = join(dirname(__file__), "initramfs")
         with open(self.plugin.initramfs_real_path, 'w+') as f:
             f.write("test")
+        self.plugin._initramfs_hash = None
         self.assertTrue(self.plugin._check_initramfs_update_available())
 
         # Explicitly get valid initramfs
         with open(self.plugin.initramfs_real_path, 'wb') as f:
             f.write(requests.get(self.plugin.initramfs_url).content)
+        self.plugin._initramfs_hash = None
         self.assertFalse(self.plugin._check_initramfs_update_available())
 
         remove(self.plugin.initramfs_real_path)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -59,6 +59,7 @@ class PluginTests(unittest.TestCase):
 
     def test_get_initramfs_latest(self):
         real_url = self.plugin.initramfs_url
+        self.plugin._initramfs_hash = None
 
         # Check invalid URL
         self.plugin.initramfs_url = None
@@ -67,6 +68,7 @@ class PluginTests(unittest.TestCase):
         self.plugin.initramfs_url = real_url
 
         # Update already downloaded and applied
+        self.plugin._initramfs_hash = None
         self.plugin.initramfs_update_path = join(dirname(__file__), "update")
         self.plugin.initramfs_real_path = join(dirname(__file__), "initramfs")
         with open(self.plugin.initramfs_real_path, 'w+') as f:
@@ -76,8 +78,10 @@ class PluginTests(unittest.TestCase):
         self.assertFalse(self.plugin._get_initramfs_latest())
 
         # Update already downloaded not applied
+        self.plugin._initramfs_hash = None
         with open(self.plugin.initramfs_update_path, 'w') as f:
             f.write("test 2")
+        self.assertTrue(self.plugin._get_initramfs_latest())
 
         # TODO: Test download hash
         remove(self.plugin.initramfs_update_path)


### PR DESCRIPTION
# Description
Update to support getting initramfs hash from `boot` partition to fix update errors

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->