### PR TITLE
Add endpoint to check download status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ PHAL:
       initramfs_url: "https://github.com/NeonGeckoCom/neon_debos/raw/{}/overlays/02-rpi4/boot/firmware/initramfs"
       initramfs_path: /opt/neon/firmware/initramfs
       initramfs_update_path: /opt/neon/initramfs
-      squashfs_url: "https://2222.us/app/files/neon_images/pi/mycroft_mark_2/updates/{}/"
       squashfs_path: /opt/neon/update.squashfs
       default_track: dev
 ```

--- a/README.md
+++ b/README.md
@@ -54,3 +54,15 @@ Check for an available InitramFS update and emit a response with data:
 ```python
 Message("neon.update_squashfs", {'track': 'dev'})
 ```
+
+### Get Build Info
+Get metadata for currently installed build:
+```python
+Message("neon.device_updater.get_build_info")
+```
+
+### Get Download Status
+Query the plugin if an update is currently downloading:
+```python
+Message("neon.device_updater.get_download_status")
+```

--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -77,9 +77,8 @@ class DeviceUpdater(PHALPlugin):
     @property
     def squashfs_url(self):
         log_deprecation("FTP update references are deprecated.", "1.0.0")
-        return self.config.get("squashfs_url", "https://2222.us/app/files/"
-                                               "neon_images/pi/mycroft_mark_2/"
-                                               "updates/{}/")
+        return self.config.get("squashfs_url", "https://download.neonaiservices"
+                                               ".com/core/rpi4/updates/{}/")
 
     @property
     def initramfs_url(self):

--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -77,8 +77,9 @@ class DeviceUpdater(PHALPlugin):
     @property
     def squashfs_url(self):
         log_deprecation("FTP update references are deprecated.", "1.0.0")
-        return self.config.get("squashfs_url", "https://download.neonaiservices"
-                                               ".com/core/rpi4/updates/{}/")
+        return self.config.get("squashfs_url",
+                               "https://download.neonaiservices.com/neon_os/"
+                               "core/rpi4/updates/{}/")
 
     @property
     def initramfs_url(self):

--- a/neon_phal_plugin_device_updater/__init__.py
+++ b/neon_phal_plugin_device_updater/__init__.py
@@ -60,6 +60,7 @@ class DeviceUpdater(PHALPlugin):
         self._default_branch = self.config.get("default_track") or "master"
         self._build_info = None
         self._initramfs_hash = None
+        self._downloading = False
 
         # Register messagebus listeners
         self.bus.on("neon.check_update_initramfs", self.check_update_initramfs)
@@ -70,6 +71,8 @@ class DeviceUpdater(PHALPlugin):
                     self.check_update_available)
         self.bus.on("neon.device_updater.get_build_info",
                     self.get_build_info)
+        self.bus.on("neon.device_updater.get_download_status",
+                    self.get_download_status)
 
     @property
     def squashfs_url(self):
@@ -233,8 +236,7 @@ class DeviceUpdater(PHALPlugin):
 
         return self._stream_download_file(download_url, download_path)
 
-    @staticmethod
-    def _stream_download_file(download_url: str,
+    def _stream_download_file(self, download_url: str,
                               download_path: str) -> Optional[str]:
         """
         Download a remote resource to a local path and return the path to the
@@ -247,6 +249,7 @@ class DeviceUpdater(PHALPlugin):
         # Download the update
         LOG.info(f"Downloading update from {download_url}")
         temp_dl_path = f"{download_path}.download"
+        self._downloading = True
         try:
             with requests.get(download_url, stream=True) as stream:
                 with open(temp_dl_path, 'wb') as f:
@@ -258,14 +261,17 @@ class DeviceUpdater(PHALPlugin):
             if file_mib < 100:
                 LOG.error(f"Downloaded file is too small ({file_mib}MiB)")
                 remove(temp_dl_path)
+                self._downloading = False
                 return
             shutil.move(temp_dl_path, download_path)
             LOG.info(f"Saved download to {download_path}")
+            self._downloading = False
             return download_path
         except Exception as e:
             LOG.exception(e)
             if isfile(temp_dl_path):
                 remove(temp_dl_path)
+        self._downloading = False
 
     def _get_gh_latest_release_tag(self, track: str = None) -> str:
         """
@@ -433,13 +439,14 @@ class DeviceUpdater(PHALPlugin):
             download_url = update_metadata['download_url'].replace(
                 f"/{platform}/", f"/{platform}/updates/").replace(".img.xz",
                                                                   ".squashfs")
-            download_path = join(dirname(self.initramfs_update_path),
-                                 update_metadata['build_version'])
+            download_path = str(join(dirname(self.initramfs_update_path),
+                                     update_metadata['build_version']))
             if isfile(download_path):
                 LOG.info("Update already downloaded")
-                return download_path
-            update_file = self._stream_download_file(download_url,
-                                                     download_path)
+                update_file = download_path
+            else:
+                update_file = self._stream_download_file(download_url,
+                                                         download_path)
         except Exception as e:
             LOG.exception(f"Failed to get download_url: {e}")
             update_file = self._legacy_get_squashfs_latest(track)
@@ -516,3 +523,10 @@ class DeviceUpdater(PHALPlugin):
         @param message: `neon.device_updater.get_build_info` Message
         """
         self.bus.emit(message.response(self.build_info))
+
+    def get_download_status(self, message: Message):
+        """
+        Handle a request to check if a download is in-progress
+        @param message: `neon.device_updater.get_download_status` Message
+        """
+        self.bus.emit(message.response(data={"downloading": self._downloading}))

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -278,11 +278,11 @@ class PluginTests(unittest.TestCase):
         pass
 
     def test_stream_download_file(self):
-        valid_os_url = "https://2222.us/app/files/neon_images/test_images/test_os.img.xz"
-        valid_update_file = "https://2222.us/app/files/neon_images/test_images/update_file.squashfs"
-        invalid_update_file = "https://2222.us/app/files/neon_images/test_images/metadata.json"
-        valid_path = "https://2222.us/app/files/neon_images/test_images/"
-        invalid_path = "https://2222.us/app/files/neon_images/invalid_directory/"
+        valid_os_url = "https://download.neonaiservices.com/test_images/test_os.img.xz"
+        valid_update_file = "https://download.neonaiservices.com/test_images/update_file.squashfs"
+        invalid_update_file = "https://download.neonaiservices.com/test_images/metadata.json"
+        valid_path = "https://download.neonaiservices.com/test_images/"
+        invalid_path = "https://download.neonaiservices.com/invalid_directory/"
 
         _, output_path = mkstemp()
         remove(output_path)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -28,7 +28,8 @@
 import logging
 import unittest
 from tempfile import mkstemp
-from time import time
+from threading import Thread
+from time import time, sleep
 
 import requests
 
@@ -292,13 +293,45 @@ class PluginTests(unittest.TestCase):
         self.assertFalse(isfile(output_path))
         self.plugin._stream_download_file(invalid_path, output_path)
         self.assertFalse(isfile(output_path))
+        self.assertFalse(self.plugin._downloading)
 
-        self.plugin._stream_download_file(valid_os_url, output_path)
+        thread = Thread(target=self.plugin._stream_download_file,
+                        args=(valid_os_url, output_path))
+        thread.start()
+        sleep(0.5)
+        self.assertTrue(self.plugin._downloading)
+        thread.join()
         self.assertTrue(isfile(output_path))
+        self.assertFalse(self.plugin._downloading)
         remove(output_path)
-        self.plugin._stream_download_file(valid_update_file, output_path)
+
+        thread = Thread(target=self.plugin._stream_download_file,
+                        args=(valid_update_file, output_path))
+        thread.start()
+        sleep(0.5)
+        self.assertTrue(self.plugin._downloading)
+        thread.join()
         self.assertTrue(isfile(output_path))
+        self.assertFalse(self.plugin._downloading)
         remove(output_path)
+
+    def test_get_build_info(self):
+        resp = self.plugin.bus.wait_for_response(
+            Message("neon.device_updater.get_build_info"))
+        self.assertEqual(resp.data, self.plugin.build_info)
+
+    def test_get_download_status(self):
+        self.assertFalse(self.plugin._downloading)
+        resp = self.plugin.bus.wait_for_response(Message(
+            "neon.device_updater.get_download_status"))
+        self.assertFalse(resp.data['downloading'])
+
+        self.plugin._downloading = True
+        resp = self.plugin.bus.wait_for_response(Message(
+            "neon.device_updater.get_download_status"))
+        self.assertTrue(resp.data['downloading'])
+
+        self.plugin._downloading = False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description
Add `neon.device_updater.get_download_status` endpoint
Update tests and documentation
Updates `2222.us` references to `download.neonaiservices.com`

# Issues
Contributes to https://github.com/NeonGeckoCom/skill-update/issues/91

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->